### PR TITLE
Utility scripts for working with the $links command

### DIFF
--- a/utilities/yak-links-extract-tweets.sh
+++ b/utilities/yak-links-extract-tweets.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+YAK_LINKS="$1"
+
+tail +2 "$1" \
+	| sed -e 's/^.*", "//' \
+	| sed -e 's/"$//' \
+	| sed -e 's/; /\n/g' \
+	| sed -e 's/\()\|),\|)\.\)$//' \
+	| sed -e 's/?s=.*$//' \
+	| cat -n \
+	| sort -uk2 \
+	| sort -n \
+	| cut -f2- \
+	| grep -E "https://(www\.)?twitter\.com/.*/status/.*"

--- a/utilities/yak-links-to-markdown.sh
+++ b/utilities/yak-links-to-markdown.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Requires the following non-default Debian packages:
+#
+#     python3-bs4
+
+YAK_LINKS="$1"
+
+while read -r URL; do
+	TITLE="$(python3 -c "import bs4, requests; print(bs4.BeautifulSoup(requests.get('$URL').text).title.text)" 2> /dev/null)"
+	TITLE="$(echo "$TITLE" | sed -e '/^$/d')"
+	TITLE="$(echo "$TITLE" | tr '\n' ' ')"
+	TITLE="$(echo "$TITLE" | sed -e 's/ \+/ /g')"
+	TITLE="$(echo "$TITLE" | sed -e 's/^\s\+//')"
+	TITLE="$(echo "$TITLE" | sed -e 's/\s\+$//')"
+	if [[ -n "$TITLE" ]] && [[ "$TITLE" != "403 Forbidden" ]] && [[ "$TITLE" != "Sorry! Something went wrong!" ]]; then
+		echo "[$TITLE]($URL)  "
+	fi
+done < <(tail +2 "$1" \
+        | sed -e 's/^.*", "//' \
+        | sed -e 's/"$//' \
+        | sed -e 's/; /\n/g' \
+        | sed -e 's/(\([^()]\+\))/%28\1%29/g' \
+        | sed -e 's/\()\|),\|)\.\)$//' \
+        | sed -e 's/?\(l\|t\|s\|usp\|gclid\|twclid\|utm_source\|utm_medium\|utm_campaign\|pf_rd_r\|pf_rd_p\|pd_rd_r\|pd_rd_w\|pd_rd_wg\|ref_\|source\|psc\|ref\)=.*$//' \
+        | sed -e '/https:\/\/discord\.com\//d' \
+        | sed -e '/https:\/\/www\.notion\.so\//d' \
+        | sed -e '/https:\/\/twitter\.com\//d' \
+        | cat -n \
+        | sort -uk2 \
+        | sort -n \
+        | cut -f2-)


### PR DESCRIPTION
Two utility scripts for helping parse exhaust for Yak Trails.

**yak-links-to-markdown.sh**

Given the file generated by `$links`, output a "list" (lines separated by `<br>` tags after processing) of each page title, linked to that page. Tracking and other URL GET cruft is discarded. Pages that error out or don't have a title are skipped. Twitter, Discord, and Notion links are skipped (as they never produce usable titles).

Note that every line is purposefully followed by two space characters.

Requires `python3-bs4`.

**yak-links-extract-tweets.sh**

Because tweets are discarded by `yak-links-to-markdown.sh` but might still be interesting, this script just extracts them (and only them) from the file generated by `$links`.

Should work on Debian using only default packages.